### PR TITLE
Upgrade to HTML5 & Responsive web design

### DIFF
--- a/dqm/E3AlarmLimits.py
+++ b/dqm/E3AlarmLimits.py
@@ -159,7 +159,7 @@ class E3AlarmLimits:
     def html(self):
         """ Html formatting.
         """
-        return '[<font class="error">%s</font> / <font class="warning">%s</font> &ndash; <font class="warning">%s</font> / <font class="error">%s</font>]'%\
+        return '[<span class="error">%s</span> / <span class="warning">%s</span> &ndash; <span class="warning">%s</span> / <span class="error">%s</span>]'%\
             (formatNumber(self.ErrorMin), formatNumber(self.WarningMin),
              formatNumber(self.WarningMax), formatNumber(self.ErrorMax))
 

--- a/dqm/E3DqmReport.py
+++ b/dqm/E3DqmReport.py
@@ -230,7 +230,7 @@ class E3DqmReport:
         outputFile.write('<p></p>\n')
         for objName in ['RateSummary', 'WeatherSummary']:
             img = '%s.png' % self.canvasName(objName)
-            outputFile.image(img, width = '49%')
+            outputFile.image(img, style = 'width:49%', alt = 'plot')
         outputFile.section('Summary')
         inputFile = E3InputRootFile(self.__InputFilePath)
         station = inputFile.station()
@@ -260,7 +260,7 @@ class E3DqmReport:
                        csvWeatherAnchor))
         outputFile.write('</ul>\n')
         outputFile.section('Summary plots')
-        outputFile.write('\n<table width=100%>\n')
+        outputFile.write('\n<table style="width:100%">\n')
         outputFile.write('%s\n' % htmlTableHeader('Plot'))
 
         def _htmlTableRow(objName, linkPlot = True, index = None):

--- a/dqm/E3DqmRunMonitor.py
+++ b/dqm/E3DqmRunMonitor.py
@@ -164,7 +164,7 @@ class E3DqmRunMonitor:
         outputFile.write('<p></p>\n')
         for objName, alarmName in TOP_IMAGES:
             img = '%s.png' % self.canvasName(objName, alarmName)
-            outputFile.image(img, width = '49%')
+            outputFile.image(img, style = 'width:49%', alt = 'plot')
         outputFile.section('Run summary')
         header = self.__InputFile.Get('Header')
         header.GetEntry(0)
@@ -213,7 +213,7 @@ class E3DqmRunMonitor:
             outputFile.li('Weather station data not found.')
         outputFile.write('</ul>\n')
         outputFile.section('Alarm summary')
-        outputFile.write('\n<table width=100%>\n')
+        outputFile.write('\n<table style="width:100%">\n')
         outputFile.write('%s\n' % E3Alarm.HTML_TABLE_HEADER)
 
         def _htmlTableRow(objName, linkPlot = True, index = None):

--- a/dqm/E3DqmRunMonitor.py
+++ b/dqm/E3DqmRunMonitor.py
@@ -213,6 +213,7 @@ class E3DqmRunMonitor:
             outputFile.li('Weather station data not found.')
         outputFile.write('</ul>\n')
         outputFile.section('Alarm summary')
+        outputFile.write('\n<div style="overflow-x:auto">\n')
         outputFile.write('\n<table style="width:100%">\n')
         outputFile.write('%s\n' % E3Alarm.HTML_TABLE_HEADER)
 
@@ -242,7 +243,7 @@ class E3DqmRunMonitor:
                 outputFile.write('%s\n' % item.htmlTableRow(True, i))
             elif isinstance(item, str):
                 outputFile.write('%s\n' % _htmlTableRow(item, True, i))
-        outputFile.write('</table>\n<p></p>\n')
+        outputFile.write('</table>\n</div>\n<p></p>\n')
         outputFile.close()
         logger.info('Done.')
         

--- a/dqm/E3HtmlOutputFile.py
+++ b/dqm/E3HtmlOutputFile.py
@@ -28,12 +28,12 @@ from e3pipe.__logging__ import logger
 
 HTML_HEADER = \
 """
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 
 <html lang="en">
   
 <head>
-<meta http-equiv="content-type" content="text/html; charset=iso-8859-1">
+<meta charset="UTF-8">
 <title>%s</title>
 <link rel="stylesheet" href="%s" type="text/css" media="all">
 </head>
@@ -54,8 +54,8 @@ HTML_FOOTER = \
 Extreme Energy Events (EEE) is powered by
 <a href="https://github.com/centrofermi/e3pipe">e3pipe</a> version %s.<br>
 This page validates as
-<a href="http://validator.w3.org/check?uri=referer">HTML 4.01 strict</a> and 
-<a href="http://jigsaw.w3.org/css-validator/check/referer">css level 3</a>.<br>
+<a href="https://validator.w3.org/check?uri=referer">HTML5</a> and 
+<a href="https://jigsaw.w3.org/css-validator/check/referer">css level 3</a>.<br>
 Generated on %s.
 </div>
 </body>

--- a/dqm/E3HtmlOutputFile.py
+++ b/dqm/E3HtmlOutputFile.py
@@ -34,6 +34,7 @@ HTML_HEADER = \
   
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <title>%s</title>
 <link rel="stylesheet" href="%s" type="text/css" media="all">
 </head>

--- a/dqm/e3pipe.css
+++ b/dqm/e3pipe.css
@@ -125,14 +125,14 @@ tr.even
 #container
 {
     margin: 0em auto;
-    width: 1000px;
+    max-width: 1000px;
     text-align: left;
     background: #fff;
 }
 
 #header
 {
-    height: 67px;
+    min-height: 67px;
     width: 100%;
     position: relative;
     background: url(../images/header.png) repeat 0 0;
@@ -251,7 +251,7 @@ tr.even
 #footer
 {
     margin: 0em auto;
-    width: 1000px;
+    max-width: 1000px;
     clear: both;
     text-align: center;
     font-size: 83%;


### PR DESCRIPTION
Upgraded to [HTML5](https://www.w3.org/TR/html5/).
[HTML 4.01](https://www.w3.org/TR/html401/) was superseded on 27 March 2018.
Added responsive design support.
Code not tested!!!
-Luca (GitHub account is of a friend of mine)